### PR TITLE
Add support PHP 8.1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,9 +24,9 @@
         <email>leigh@php.net</email>
         <active>yes</active>
     </lead>
-    <date>2020-12-02</date>
+    <date>2022-04-14</date>
     <version>
-        <release>1.0.4</release>
+        <release>1.0.5</release>
         <api>1.0.0</api>
     </version>
     <stability>
@@ -106,8 +106,8 @@
         <required>
             <php>
                 <min>7.2.0</min>
-                <max>8.1.0</max>
-                <exclude>8.1.0</exclude>
+                <max>8.2.0</max>
+                <exclude>8.2.0</exclude>
             </php>
             <pearinstaller>
                 <min>1.4.0</min>

--- a/php_mcrypt.h
+++ b/php_mcrypt.h
@@ -29,7 +29,7 @@
 extern zend_module_entry mcrypt_module_entry;
 #define mcrypt_module_ptr &mcrypt_module_entry
 
-#define PHP_MCRYPT_VERSION "1.0.4"
+#define PHP_MCRYPT_VERSION "1.0.5"
 
 /* Functions for both old and new API */
 PHP_FUNCTION(mcrypt_ecb);


### PR DESCRIPTION
1.0.4 works fine with PHP 8.1 as it is now, but it seems that it cannot be installed from PECL due to a limitation in package.xml.
I would like to see it released as 1.0.5 with no changes to the implementation.