### PR TITLE
Release 1.0.6 with package support for PHP 8.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,11 @@
         <email>leigh@php.net</email>
         <active>yes</active>
     </lead>
+    <date>2023-02-23</date>
+    <version>
+        <release>1.0.6</release>
+        <api>1.0.0</api>
+    </version>
     <date>2022-04-14</date>
     <version>
         <release>1.0.5</release>
@@ -106,8 +111,8 @@
         <required>
             <php>
                 <min>7.2.0</min>
-                <max>8.2.0</max>
-                <exclude>8.2.0</exclude>
+                <max>8.3.0</max>
+                <exclude>8.3.0</exclude>
             </php>
             <pearinstaller>
                 <min>1.4.0</min>

--- a/php_mcrypt.h
+++ b/php_mcrypt.h
@@ -29,7 +29,7 @@
 extern zend_module_entry mcrypt_module_entry;
 #define mcrypt_module_ptr &mcrypt_module_entry
 
-#define PHP_MCRYPT_VERSION "1.0.5"
+#define PHP_MCRYPT_VERSION "1.0.6"
 
 /* Functions for both old and new API */
 PHP_FUNCTION(mcrypt_ecb);


### PR DESCRIPTION
Debian 11 `libmcrypt-dev` and Alpine 3.16 `libmcrypt-dev` works fine, add support for install from PECL.

Closes: #12