### PR TITLE
Release 1.0.7 with support for PHP 8.3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,9 +24,9 @@
         <email>leigh@php.net</email>
         <active>yes</active>
     </lead>
-    <date>2023-02-28</date>
+    <date>2023-12-12</date>
     <version>
-        <release>1.0.6</release>
+        <release>1.0.7</release>
         <api>1.0.0</api>
     </version>
     <stability>
@@ -35,7 +35,7 @@
     </stability>
     <license uri="http://www.php.net/license">PHP License</license>
     <notes>
-        - Make release to advertise PHP 8.2 support, which it already had.
+        - Make release to advertise PHP 8.3 support, which it already had.
     </notes>
     <contents>
         <dir name="/">
@@ -106,8 +106,8 @@
         <required>
             <php>
                 <min>7.2.0</min>
-                <max>8.3.0</max>
-                <exclude>8.3.0</exclude>
+                <max>8.4.0</max>
+                <exclude>8.4.0</exclude>
             </php>
             <pearinstaller>
                 <min>1.4.0</min>

--- a/php_mcrypt.h
+++ b/php_mcrypt.h
@@ -29,7 +29,7 @@
 extern zend_module_entry mcrypt_module_entry;
 #define mcrypt_module_ptr &mcrypt_module_entry
 
-#define PHP_MCRYPT_VERSION "1.0.6"
+#define PHP_MCRYPT_VERSION "1.0.7"
 
 /* Functions for both old and new API */
 PHP_FUNCTION(mcrypt_ecb);


### PR DESCRIPTION
Update package.xml to allow installation of mcrypt through pecl in a php 8.3 environment.

Tests pass on alpine linux v3.18 with php 8.3.0; attached the test
results.

[php_test_results_20231212_0204.txt](https://github.com/php/pecl-encryption-mcrypt/files/13642953/php_test_results_20231212_0204.txt)
